### PR TITLE
Regex change to detect only HANA in sapservices

### DIFF
--- a/Freeze-Thaw Examples/sap-hana/hana-post-thaw.sh
+++ b/Freeze-Thaw Examples/sap-hana/hana-post-thaw.sh
@@ -19,6 +19,7 @@
 #                      Optionally use config in separate file
 # 1.1 - Dec 6, 2017 -  Bugfixes for key authentication, exit code status,
 #                      and config file support
+# 1.2 - Sep 4, 2020 SZ Small changes to regex to detect HANA services
 
 ####################################################################
 #
@@ -156,8 +157,8 @@ read_sapservices() {
         exit_code=1
     fi
 
-    subexp="pf\=.*|-u *[[:alnum:]]{6}|-D"
-    expression="/usr/sap/[[:alnum:]]{3}/.*sapstartsrv *${subexp} *${subexp} *${subexp}"
+    subexp="(pf\=.*|-u *[[:alnum:]]{6}|-D)"
+    expression="/usr/sap/[[:alnum:]]{3}/HDB.*sapstartsrv *${subexp} *${subexp} *${subexp}"
 
     lines=`cat ${sapservices_file} | wc -l`
 

--- a/Freeze-Thaw Examples/sap-hana/hana-pre-freeze.sh
+++ b/Freeze-Thaw Examples/sap-hana/hana-pre-freeze.sh
@@ -19,6 +19,7 @@
 #                      Optionally use config in separate file (-c parameter)
 # 1.1 - Dec 6, 2017 -  Bugfixes for key authentication, exit code status,
 #                      and config file support
+# 1.2 - Sep 1, 2020 SZ Small changes to regex to detect HANA services
 
 ####################################################################
 #
@@ -143,8 +144,8 @@ read_sapservices() {
             exit_code=1
     fi
 
-    subexp="pf\=.*|-u *[[:alnum:]]{6}|-D"
-    expression="/usr/sap/[[:alnum:]]{3}/.*sapstartsrv *${subexp} *${subexp} *${subexp}"
+    subexp="(pf\=.*|-u *[[:alnum:]]{6}|-D)"
+    expression="/usr/sap/[[:alnum:]]{3}/HDB.*sapstartsrv *${subexp} *${subexp} *${subexp}"
 
     lines=`cat ${sapservices_file} | wc -l`
 

--- a/Freeze-Thaw Examples/sap-hana/hana-pre-freeze.sh
+++ b/Freeze-Thaw Examples/sap-hana/hana-pre-freeze.sh
@@ -141,7 +141,7 @@ config_get() {
 read_sapservices() {	
     if [ ! -r "${sapservices_file}" ]; then
         echo  "File ${sapservices_file} not found."
-            exit_code=1
+        exit_code=1
     fi
 
     subexp="(pf\=.*|-u *[[:alnum:]]{6}|-D)"


### PR DESCRIPTION
# Pull Request Template

By contributing, you agree that your contributions will be licensed under the projects original open source license.

## Description

Customer had an issue with more SAP services running on the same machine (listed in `sapservices` file) and had errors in the pre-script with the previous auto-detection of HANA systems.
The regex change searches for the HDB string which HANA databases have in the `sapservices` file and introduces brackets to the sub-expression, so that the initial `|` does not include the first part of the upper regex.

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Partner tested in customer environment where script previously failed by detecting the other SAP services, too, now it only detects the HDB.

### Checklist (check all applicable):

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in _hard to understand_ areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
